### PR TITLE
Убраны кавычки вокруг команд скачки дистрибутивов

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -56,7 +56,7 @@ SERVERINK=$(curl -s -G \
 
 mkdir -p dist
 
-curl --fail -b /tmp/cookies.txt -o dist/client.tar.gz -L "$CLIENTLINK"
-curl --fail -b /tmp/cookies.txt -o dist/server.tar.gz -L "$SERVERINK"
+curl --fail -b /tmp/cookies.txt -o dist/client.tar.gz -L $CLIENTLINK
+curl --fail -b /tmp/cookies.txt -o dist/server.tar.gz -L $SERVERINK
 
 rm /tmp/cookies.txt


### PR DESCRIPTION
На WSL при указании кавычек вылезала ошибка
```
curl: (3) Illegal characters found in URL 
```

Убирание кавычек починило скачку.

@Infactum можешь проверить поведение?